### PR TITLE
Set SVG font to normal font

### DIFF
--- a/ipynb/oscovida/oscovida.py
+++ b/ipynb/oscovida/oscovida.py
@@ -16,6 +16,7 @@ import IPython.display
 from matplotlib import rcParams
 rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Inconsolata']
+rcParams['svg.fonttype'] = 'none'
 # need many figures for index.ipynb and germany.ipynb
 rcParams['figure.max_open_warning'] = 50
 from matplotlib.ticker import ScalarFormatter, FuncFormatter


### PR DESCRIPTION
See this answer on how to make matplotlib use usual text in SVG, not rendered curves: https://stackoverflow.com/questions/34387893/output-matplotlib-figure-to-svg-with-text-as-text-not-curves